### PR TITLE
chore: remove kopper dependency

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -20,9 +20,6 @@ dependencies:
     version: "1.0.353"
     repository: https://flanksource.github.io/charts
     condition: flanksource-ui.enabled
-  - name: kopper
-    version: "1.0.3"
-    repository: https://flanksource.github.io/charts
   - name: kratos
     version: "0.32.0"
     repository: https://k8s.ory.sh/helm/charts


### PR DESCRIPTION
chart/crds