### PR TITLE
fix: inline check for incident-commander topology

### DIFF
--- a/topologies/mission-control.yaml
+++ b/topologies/mission-control.yaml
@@ -27,7 +27,7 @@ spec:
             schedule: "@every 1m"
             http:
               - name: incident-commander-http-check
-                endpoint: http://incident-commander:8080/health
+                endpoint: http://mission-control:8080/health
                 responseCodes: [200]
       selectors:
         - name: pods


### PR DESCRIPTION
Fix for https://mission-control.azure.lab.flanksource.com/incidents/0188b8b6-fa07-0f03-dbe1-28e4c7e6c24d

Added check as definition of done