### PR TITLE
chore: set kratos log level to warning

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -172,6 +172,8 @@ kratos:
       session:
         # Session lifespan. Default: 14 days
         lifespan: 336h
+      log:
+        level: warning
 resources:
   requests:
     cpu: 200m


### PR DESCRIPTION
Fix for: https://mission-control.azure.lab.flanksource.com/incidents/0188ba7a-57cf-847a-dd97-02df7fc441bf