### PR TITLE
chore: add pganalyze defaults in agent chart

### DIFF
--- a/agent-chart/values.yaml
+++ b/agent-chart/values.yaml
@@ -84,6 +84,9 @@ db:
   resources:
     requests:
       memory: 2Gi
+  pganalyze:
+    enabled: false
+    secretName: pganalyze
 
 canary-checker:
   image:


### PR DESCRIPTION
To prevent error: ```
Error: INSTALLATION FAILED: template: mission-control-agent/templates/postgres.yaml:72:20: executing "mission-control-agent/templates/postgres.yaml" at <.Values.db.pganalyze.enabled>: nil pointer evaluating interface {}.enabled```