### PR TITLE
chore: fix postgres secret handling for tenant

### DIFF
--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -29,7 +29,7 @@
 {{- $kratosSecret := ((lookup "v1" "Secret" .Release.Namespace (include "kratos-im.secretname" .)).data | default dict) -}}
 {{- $kratosDSN := (print "postgres://" $user ":" $password "@" $host "/" $database) -}}
 
-# Change kratos DSN to generated DB_URL
+{{- if .Values.db.create }}
 ---
 apiVersion: v1
 kind: Secret
@@ -44,6 +44,8 @@ stringData:
   SSLMODE: {{ $sslmode | quote }}
   DB_URL:  {{ (print "postgres://" $user ":" $password "@" $postgresHost "/" $database "?sslmode=" $sslmode ) | quote }}
   DATABASE: {{ $database | quote }}
+
+{{- end }}
 
 {{- if eq .Values.authProvider "kratos" }}
 ---


### PR DESCRIPTION
@moshloop @dabasvibhor 

There was a if db.create condition which we use to toggle the incident commander DB creation.

That line was removed in https://github.com/flanksource/mission-control-chart/pull/143 , not sure if that was intentional but right now all tenant releases are broken because its trying to overwrite the existing tenant secrets

Re adding those conditions back