### PR TITLE
chore: db.storageClass should be string default

### DIFF
--- a/.github/workflows/agent-test.yml
+++ b/.github/workflows/agent-test.yml
@@ -25,5 +25,4 @@ jobs:
           helm template . \
             --set upstream.host=host \
             --set upstream.password=password \
-            --set upstream.agentName=agent \
-            --set db.storageClass=default \
+            --set upstream.agentName=agent

--- a/agent-chart/values.yaml
+++ b/agent-chart/values.yaml
@@ -82,7 +82,7 @@ db:
   jwtSecretKeyRef:
     name: incident-commander-postgrest-jwt
     key: PGRST_JWT_SECRET
-  storageClass:
+  storageClass: ''
   storage: 20Gi
   shmVolume: 256Mi
   resources:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -115,7 +115,7 @@ db:
   jwtSecretKeyRef:
     name: incident-commander-postgrest-jwt
     key: PGRST_JWT_SECRET
-  storageClass:
+  storageClass: ''
   storage: 20Gi
   shmVolume: 256Mi
   resources:


### PR DESCRIPTION
Error:
```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
mission-control-agent:
- db.storageClass: Invalid type. Expected: string, given: null
```