### PR TITLE
fix: setup kratos admin base url

### DIFF
--- a/chart/files/kratos-config.yaml
+++ b/chart/files/kratos-config.yaml
@@ -9,8 +9,9 @@ serve:
     base_url: 'https://{{ tpl (index .Values "flanksource-ui" "ingress" "host") . }}/api/.ory'
     cors:
       enabled: true
-  # admin:
-  #   base_url: http://127.0.0.1:4434/
+  admin:
+    base_url: 'http://kratos-admin'
+    port: 4434
 selfservice:
   default_browser_return_url: 'https://{{ tpl (index .Values "flanksource-ui" "ingress" "host") . }}/'
   allowed_return_urls:


### PR DESCRIPTION
```
time=2024-09-05T09:06:58Z level=warning msg=The config has no version specified. Add the version to improve your development experience. audience=application service_name=Ory Kratos service_version=v0.13.0
time=2024-09-09T19:37:28Z level=warning msg=Configuration key serve.admin.base_url was left empty. Optimistically guessing the server's base URL. Please set a value to avoid problems with redirects and cookies. audience=application service_name=Ory Kratos service_version=v0.13.0
time=2024-09-10T05:32:03Z level=warning msg=Configuration key serve.admin.base_url was left empty. Optimistically guessing the server's base URL. Please set a value to avoid problems with redirects and cookies. audience=application service_name=Ory Kratos service_version=v0.13.0
time=2024-09-10T14:25:30Z level=warning msg=Configuration key serve.admin.base_url was left empty. Optimistically guessing the server's base URL. Please set a value to avoid problems with redirects and cookies. audience=application service_name=Ory Kratos service_version=v0.13.0
time=2024-09-10T14:32:28Z level=warning msg=Configuration key serve.admin.base_url was left empty. Optimistically guessing the server's base URL. Please set a value to avoid problems with redirects and cookies. audience=application service_name=Ory Kratos service_version=v0.13.0
time=2024-09-10T14:37:36Z level=warning msg=Configuration key serve.admin.base_url was left empty. Optimistically guessing the server's base URL. Please set a value to avoid problems with redirects and cookies. audience=application service_name=Ory Kratos service_version=v0.13.0
time=2024-09-11T15:21:22Z level=warning msg=Configuration key serve.admin.base_url was left empty. Optimistically guessing the server's base URL. Please set a value to avoid problems with redirects and cookies. audience=application service_name=Ory Kratos service_version=v0.13.0
time=2024-09-11T15:24:47Z level=warning msg=Configuration key serve.admin.base_url was left empty. Optimistically guessing the server's base URL. Please set a value to avoid problems with redirects and cookies. audience=application service_name=Ory Kratos service_version=v0.13.0
```

resolves: https://github.com/flanksource/mission-control/issues/1378

When the kratos client makes call to any admin endpoints (eg: updating traits of identities), it requires the admin url. If not provided it uses the kratos api URL with port `4434`.

```
"https://kratos-6c96d4c97f-p7rq2:4434/admin/identities/5146f95d-0180-43c5-bc43-92460d3b021e\": dial tcp: lookup kratos-6c96d4c97f-p7rq2 on 172.20.0.10:53: no such host
```

Setting the admin base_url solves this.