### PR TITLE
fix: identity role mapper volume mount

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -31,11 +31,6 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.global.imageRegistry }}/{{.Values.global.imagePrefix}}/incident-commander:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if ne .Values.identityRoleMapper.configMap.name ""}}
-          volumeMounts:
-            - name: identity-role-mapper
-              mountPath: {{ .Values.identityRoleMapper.configMap.mountPath}}
-          {{- end}}
           env:
             {{- if (tpl .Values.otel.labels .)}}
             - name: OTEL_LABELS
@@ -129,6 +124,10 @@ spec:
             - mountPath: /app/mission-control.properties
               name: properties-config
               subPath: mission-control.properties
+            {{- if ne .Values.identityRoleMapper.configMap.name ""}}
+            - name: identity-role-mapper
+              mountPath: {{ .Values.identityRoleMapper.configMap.mountPath}}
+            {{- end}}
       {{- with .Values.extra }}
       {{- toYaml . | nindent 6 }}
       {{- end }}


### PR DESCRIPTION
resolves:  Warning  error  4m9s (x8 over 109m)  helm-controller  reconciliation failed: Helm upgrade failed: error while running post render on files: map[string]interface {}(nil): yaml:
unmarshal errors:                                                                                                                                                               
 line 101: mapping key "volumeMounts" already defined at line 42      