### PR TITLE
Add scopes resource to RBAC permissions

### DIFF
--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -25,15 +25,16 @@ rules:
 - apiGroups:
   - mission-control.flanksource.com
   resources:
+  - applications
   - connections
   - incidentrules
-  - playbooks
   - notifications
   - notificationsilences
   - permissiongroups
   - permissions
+  - playbooks
+  - scopes
   - views
-  - applications
   verbs:
   - create
   - delete


### PR DESCRIPTION
## Summary

Adds the scopes resource to the service account RBAC permissions, enabling management of permission scopes through the API.

resolves: https://github.com/flanksource/mission-control-chart/issues/259