### PR TITLE
fix: update rbac to handle scope finalizers and status

### DIFF
--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -55,6 +55,7 @@ rules:
   - permissions/finalizers
   - views/finalizers
   - applications/finalizers
+  - scopes/finalizers
   verbs:
   - update
 - apiGroups:
@@ -69,6 +70,7 @@ rules:
   - permissions/status
   - views/status
   - applications/status
+  - scopes/status
   verbs:
   - get
   - patch


### PR DESCRIPTION
```
{"time":"2025-11-20T05:02:22.123895824Z","level":"ERROR","msg":"[kopper] failed to update status Scope[99369e0b-3581-4de0-aa11-4de4680d9fb1]: scopes.mission-control.flanksource.com \"redacted\" is forbidden: User \"system:serviceaccount:mission-control:mission-control-sa\" cannot update resource \"scopes/status\" in API group \"mission-control.flanksource.com\" in the namespace \"redacted\""}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated RBAC permissions to enable scope management operations, including finalization and status update capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->