### PR TITLE
feat(chart): add artifactstore rclone-backed s3 service

### DIFF
--- a/agent-chart/README.md
+++ b/agent-chart/README.md
@@ -14,14 +14,18 @@ A Helm chart for flanksource mission control agent
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://flanksource.github.io/charts | canary-checker | 1.1.3-beta.81 |
-| https://flanksource.github.io/charts | config-db | 0.0.1182 |
-| https://flanksource.github.io/charts | pushTelemetry(mission-control-watchtower) | 0.1.34 |
+| https://flanksource.github.io/charts | canary-checker | 1.1.3-beta.107 |
+| https://flanksource.github.io/charts | config-db | 0.0.1339 |
+| https://flanksource.github.io/charts | pushTelemetry(mission-control-watchtower) | 0.1.35-beta.4 |
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| adminPassword.secretKeyRef.create | bool | `true` |  |
+| adminPassword.secretKeyRef.key | string | `"password"` |  |
+| adminPassword.secretKeyRef.name | string | `"mission-control-admin-password"` |  |
+| authProvider | string | `"basic"` |  |
 | canary-checker.db.external.create | bool | `false` |  |
 | canary-checker.db.external.enabled | bool | `true` |  |
 | canary-checker.db.external.secretKeyRef.key | string | `"DB_URL"` |  |
@@ -88,9 +92,12 @@ A Helm chart for flanksource mission control agent
 | global.imageRegistry | string | `"public.ecr.aws"` |  |
 | global.labels | object | `{}` |  |
 | global.logLevel | string | `""` |  |
+| htpasswd.create | bool | `true` |  |
+| htpasswd.secretKey | string | `"htpasswd"` |  |
+| htpasswd.secretName | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"docker.io/flanksource/incident-commander"` |  |
-| image.tag | string | `"v0.0.1563"` |  |
+| image.tag | string | `"v0.0.1711"` |  |
 | jsonLogs | bool | `true` |  |
 | logLevel | string | `"{{.Values.global.logLevel}}"` |  |
 | properties."upstream.pull_playbook_actions" | bool | `true` |  |

--- a/agent-chart/values.schema.json
+++ b/agent-chart/values.schema.json
@@ -2,6 +2,53 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": true,
   "properties": {
+    "adminPassword": {
+      "additionalProperties": false,
+      "properties": {
+        "secretKeyRef": {
+          "additionalProperties": false,
+          "properties": {
+            "create": {
+              "default": true,
+              "description": "set to false if you want to pass in an existing secret",
+              "required": [],
+              "title": "create",
+              "type": "boolean"
+            },
+            "key": {
+              "default": "password",
+              "required": [],
+              "title": "key",
+              "type": "string"
+            },
+            "name": {
+              "default": "mission-control-admin-password",
+              "required": [],
+              "title": "name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "create",
+            "name",
+            "key"
+          ],
+          "title": "secretKeyRef",
+          "type": "object"
+        }
+      },
+      "required": [
+        "secretKeyRef"
+      ],
+      "title": "adminPassword",
+      "type": "object"
+    },
+    "authProvider": {
+      "default": "basic",
+      "required": [],
+      "title": "authProvider",
+      "type": "string"
+    },
     "canary-checker": {
       "additionalProperties": true,
       "required": [],
@@ -448,6 +495,36 @@
       "title": "global",
       "type": "object"
     },
+    "htpasswd": {
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "default": true,
+          "required": [],
+          "title": "create",
+          "type": "boolean"
+        },
+        "secretKey": {
+          "default": "htpasswd",
+          "required": [],
+          "title": "secretKey",
+          "type": "string"
+        },
+        "secretName": {
+          "default": "",
+          "required": [],
+          "title": "secretName",
+          "type": "string"
+        }
+      },
+      "required": [
+        "create",
+        "secretName",
+        "secretKey"
+      ],
+      "title": "htpasswd",
+      "type": "object"
+    },
     "image": {
       "additionalProperties": false,
       "description": "yaml-language-server: $schema=values.schema.json\nUse this only if you want to replace the default that is .Chart.Name as the name of all the objects.",
@@ -465,7 +542,7 @@
           "type": "string"
         },
         "tag": {
-          "default": "v0.0.1565",
+          "default": "v0.0.1711",
           "required": [],
           "title": "tag",
           "type": "string"
@@ -739,6 +816,9 @@
     "jsonLogs",
     "serviceAccount",
     "upstream",
+    "authProvider",
+    "adminPassword",
+    "htpasswd",
     "resources",
     "pushTelemetry",
     "db",

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,13 +4,13 @@ dependencies:
   version: 0.0.47
 - name: config-db
   repository: https://flanksource.github.io/charts
-  version: 0.0.1281
+  version: 0.0.1339
 - name: canary-checker
   repository: https://flanksource.github.io/charts
-  version: 1.1.3-beta.92
+  version: 1.1.3-beta.107
 - name: flanksource-ui
   repository: https://flanksource.github.io/charts
-  version: 1.4.230
+  version: 1.4.238
 - name: kratos
   repository: https://k8s.ory.sh/helm/charts
   version: 0.60.1
@@ -20,5 +20,5 @@ dependencies:
 - name: mission-control-misc-playbooks
   repository: https://flanksource.github.io/charts
   version: 0.1.2
-digest: sha256:e021bb53448a186cf0b8a64baac7be9ea038b91a6c3515745013bd164dc0d018
-generated: "2026-04-03T14:07:06.690318+05:45"
+digest: sha256:f966abc60f68d67369cc22078ebc281f614efbd58d2e73702a541ed550aa3da6
+generated: "2026-04-22T10:04:12.098898+05:45"

--- a/chart/README.md
+++ b/chart/README.md
@@ -15,12 +15,12 @@ A Helm chart for flanksource mission control
 | Repository | Name | Version |
 |------------|------|---------|
 | https://flanksource.github.io/charts | apm-hub | >= 0.0.20 |
-| https://flanksource.github.io/charts | canary-checker | 1.1.3-beta.81 |
-| https://flanksource.github.io/charts | config-db | 0.0.1182 |
-| https://flanksource.github.io/charts | flanksource-ui | 1.4.184 |
+| https://flanksource.github.io/charts | canary-checker | 1.1.3-beta.107 |
+| https://flanksource.github.io/charts | config-db | 0.0.1339 |
+| https://flanksource.github.io/charts | flanksource-ui | 1.4.238 |
 | https://flanksource.github.io/charts | mission-control-kubernetes-view | >= 0.1.37 |
-| https://flanksource.github.io/charts | mission-control-misc-playbooks | 0.1.1 |
-| https://k8s.ory.sh/helm/charts | kratos | 0.32.0 |
+| https://flanksource.github.io/charts | mission-control-misc-playbooks | 0.1.2 |
+| https://k8s.ory.sh/helm/charts | kratos | 0.60.1 |
 
 ## Values
 
@@ -35,6 +35,21 @@ A Helm chart for flanksource mission control
 | apm-hub.db.secretKeyRef.name | string | `"incident-commander-postgres"` |  |
 | apm-hub.enabled | bool | `false` |  |
 | artifactConnection | string | `""` | artifact connection string |
+| artifactstore.enabled | bool | `true` |  |
+| artifactstore.image.pullPolicy | string | `"IfNotPresent"` |  |
+| artifactstore.image.repository | string | `"docker.io/rclone/rclone"` |  |
+| artifactstore.image.tag | string | `"1.71.2"` |  |
+| artifactstore.resources.limits.cpu | string | `"250m"` |  |
+| artifactstore.resources.limits.memory | string | `"256Mi"` |  |
+| artifactstore.resources.requests.cpu | string | `"25m"` |  |
+| artifactstore.resources.requests.memory | string | `"64Mi"` |  |
+| artifactstore.secretKeyRef.create | bool | `true` |  |
+| artifactstore.secretKeyRef.key | string | `"ACCESS_KEY_ID"` |  |
+| artifactstore.secretKeyRef.name | string | `"mission-control-artifactstore"` |  |
+| artifactstore.service.port | int | `8080` |  |
+| artifactstore.volume.existingClaim | string | `""` |  |
+| artifactstore.volume.storage | string | `"10Gi"` |  |
+| artifactstore.volume.storageClass | string | `""` |  |
 | authProvider | string | `"kratos"` |  |
 | canary-checker.db.external.create | bool | `false` |  |
 | canary-checker.db.external.enabled | bool | `true` |  |
@@ -125,7 +140,7 @@ A Helm chart for flanksource mission control
 | global.api.tlsSecretName | string | `""` |  |
 | global.db.connectionPooler.enabled | bool | `false` |  |
 | global.db.connectionPooler.extraContainers | string | `""` |  |
-| global.db.connectionPooler.image | string | `"bitnami/pgbouncer:1.22.0"` |  |
+| global.db.connectionPooler.image | string | `"pgbouncer/pgbouncer:1.22.0"` |  |
 | global.db.connectionPooler.secretKeyRef.key | string | `"DB_URL"` |  |
 | global.db.connectionPooler.secretKeyRef.name | string | `"mission-control-connection-pooler"` |  |
 | global.db.connectionPooler.serviceAccount.annotations | object | `{}` |  |
@@ -151,7 +166,7 @@ A Helm chart for flanksource mission control
 | identityRoleMapper.script | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"docker.io/flanksource/incident-commander"` |  |
-| image.tag | string | `"v0.0.1563"` |  |
+| image.tag | string | `"v0.0.1711"` |  |
 | impersonationRole.createNamespaces | bool | `true` |  |
 | impersonationRole.namespaces[0] | string | `"default"` |  |
 | ingress.annotations."kubernetes.io/ingress.class" | string | `"nginx"` |  |
@@ -190,12 +205,14 @@ A Helm chart for flanksource mission control
 | kratos.kratos.config.secrets.default[2] | string | `"just a random a string secret"` |  |
 | kratos.kratos.config.session.lifespan | string | `"336h"` |  |
 | kratos.secret.enabled | bool | `false` |  |
+| kratos.secret.nameOverride | string | `"kratos"` |  |
 | llmConnection | string | `""` | llm connection string |
 | logLevel | string | `"{{.Values.global.logLevel}}"` |  |
 | metricsPort | int | `0` |  |
 | mission-control-kubernetes-view | object | `{}` |  |
 | mission-control-misc-playbooks.enabled | bool | `true` |  |
 | nameOverride | string | `""` |  |
+| oidc | bool | `false` |  |
 | otel.collector | string | `"{{.Values.global.otel.collector}}"` |  |
 | otel.labels | string | `"{{ .Values.global.otel.labels }}"` |  |
 | otel.serviceName | string | `"mission-control"` |  |
@@ -230,6 +247,7 @@ A Helm chart for flanksource mission control
 | upstream_push | object | `{}` |  |
 | views.dashboard.enabled | bool | `true` |  |
 | views.dashboard.sidebar | bool | `true` |  |
+| views.database.enabled | bool | `true` |  |
 | views.enabled | bool | `true` |  |
 | views.failingHealthChecks.enabled | bool | `true` |  |
 | views.failingHealthChecks.sidebar | bool | `false` |  |

--- a/chart/README.md
+++ b/chart/README.md
@@ -35,10 +35,12 @@ A Helm chart for flanksource mission control
 | apm-hub.db.secretKeyRef.name | string | `"incident-commander-postgres"` |  |
 | apm-hub.enabled | bool | `false` |  |
 | artifactConnection | string | `""` | artifact connection string |
+| artifactstore.connection.bucket | string | `"mission-control-artifacts"` |  |
+| artifactstore.connection.name | string | `"default-artifactstore"` |  |
 | artifactstore.enabled | bool | `true` |  |
 | artifactstore.image.pullPolicy | string | `"IfNotPresent"` |  |
 | artifactstore.image.repository | string | `"docker.io/rclone/rclone"` |  |
-| artifactstore.image.tag | string | `"1.71.2"` |  |
+| artifactstore.image.tag | string | `"1.73.5"` |  |
 | artifactstore.resources.limits.cpu | string | `"250m"` |  |
 | artifactstore.resources.limits.memory | string | `"256Mi"` |  |
 | artifactstore.resources.requests.cpu | string | `"25m"` |  |

--- a/chart/README.md
+++ b/chart/README.md
@@ -41,14 +41,12 @@ A Helm chart for flanksource mission control
 | artifactstore.image.pullPolicy | string | `"IfNotPresent"` |  |
 | artifactstore.image.repository | string | `"docker.io/rclone/rclone"` |  |
 | artifactstore.image.tag | string | `"1.73.5"` |  |
-| artifactstore.resources.limits.cpu | string | `"250m"` |  |
 | artifactstore.resources.limits.memory | string | `"256Mi"` |  |
 | artifactstore.resources.requests.cpu | string | `"25m"` |  |
 | artifactstore.resources.requests.memory | string | `"64Mi"` |  |
 | artifactstore.secretKeyRef.create | bool | `true` |  |
 | artifactstore.secretKeyRef.key | string | `"ACCESS_KEY_ID"` |  |
 | artifactstore.secretKeyRef.name | string | `"mission-control-artifactstore"` |  |
-| artifactstore.service.port | int | `8080` |  |
 | artifactstore.volume.existingClaim | string | `""` |  |
 | artifactstore.volume.storage | string | `"10Gi"` |  |
 | artifactstore.volume.storageClass | string | `""` |  |

--- a/chart/README.md
+++ b/chart/README.md
@@ -35,7 +35,7 @@ A Helm chart for flanksource mission control
 | apm-hub.db.secretKeyRef.name | string | `"incident-commander-postgres"` |  |
 | apm-hub.enabled | bool | `false` |  |
 | artifactConnection | string | `""` | artifact connection string |
-| artifactstore.connection.bucket | string | `"mission-control-artifacts"` |  |
+| artifactstore.connection.bucket | string | `"artifacts"` |  |
 | artifactstore.connection.name | string | `"default-artifactstore"` |  |
 | artifactstore.enabled | bool | `false` |  |
 | artifactstore.image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -45,7 +45,6 @@ A Helm chart for flanksource mission control
 | artifactstore.resources.requests.cpu | string | `"25m"` |  |
 | artifactstore.resources.requests.memory | string | `"64Mi"` |  |
 | artifactstore.secretKeyRef.create | bool | `true` |  |
-| artifactstore.secretKeyRef.key | string | `"ACCESS_KEY_ID"` |  |
 | artifactstore.secretKeyRef.name | string | `"mission-control-artifactstore"` |  |
 | artifactstore.volume.existingClaim | string | `""` |  |
 | artifactstore.volume.storage | string | `"10Gi"` |  |

--- a/chart/README.md
+++ b/chart/README.md
@@ -37,7 +37,7 @@ A Helm chart for flanksource mission control
 | artifactConnection | string | `""` | artifact connection string |
 | artifactstore.connection.bucket | string | `"mission-control-artifacts"` |  |
 | artifactstore.connection.name | string | `"default-artifactstore"` |  |
-| artifactstore.enabled | bool | `true` |  |
+| artifactstore.enabled | bool | `false` |  |
 | artifactstore.image.pullPolicy | string | `"IfNotPresent"` |  |
 | artifactstore.image.repository | string | `"docker.io/rclone/rclone"` |  |
 | artifactstore.image.tag | string | `"1.73.5"` |  |

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -139,5 +139,6 @@ Generate the secrets.cipher value
 {{- end -}}
 
 {{- define "incident-commander.artifactstore.selectorLabels" -}}
+{{ include "incident-commander.selectorLabels" . }}
 app.kubernetes.io/component: artifactstore
 {{- end -}}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -125,3 +125,19 @@ Generate the secrets.cipher value
     {{- end -}}
   {{- end -}}
 {{- end -}}
+
+{{- define "incident-commander.artifactstore.name" -}}
+{{- printf "%s-artifactstore" (include "incident-commander.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "incident-commander.artifactstore.pvc" -}}
+{{- if .Values.artifactstore.volume.existingClaim -}}
+{{- .Values.artifactstore.volume.existingClaim -}}
+{{- else -}}
+{{- include "incident-commander.artifactstore.name" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "incident-commander.artifactstore.selectorLabels" -}}
+app.kubernetes.io/component: artifactstore
+{{- end -}}

--- a/chart/templates/artifactstore/connection.yaml
+++ b/chart/templates/artifactstore/connection.yaml
@@ -12,10 +12,10 @@ spec:
           key: {{ .Values.artifactstore.secretKeyRef.key | default "ACCESS_KEY_ID" }}
           name: {{ .Values.artifactstore.secretKeyRef.name }}
     bucket: {{ .Values.artifactstore.connection.bucket | default "mission-control-artifacts" }}
-    region: {{ .Values.artifactstore.connection.region | default "us-east-1" }}
+    region: "us-east-1"
     url:
       value: http://{{ include "incident-commander.artifactstore.name" . }}.{{ .Release.Namespace }}.svc:{{ .Values.artifactstore.service.port }}
-    usePathStyle: {{ .Values.artifactstore.connection.usePathStyle | default true }}
+    usePathStyle: true
     secretKey:
       valueFrom:
         secretKeyRef:

--- a/chart/templates/artifactstore/connection.yaml
+++ b/chart/templates/artifactstore/connection.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.artifactstore.enabled }}
+---
+apiVersion: mission-control.flanksource.com/v1
+kind: Connection
+metadata:
+  name: {{ .Values.artifactstore.connection.name | default "default-artifactstore" }}
+spec:
+  s3:
+    accessKey:
+      valueFrom:
+        secretKeyRef:
+          key: {{ .Values.artifactstore.secretKeyRef.key | default "ACCESS_KEY_ID" }}
+          name: {{ .Values.artifactstore.secretKeyRef.name }}
+    bucket: {{ .Values.artifactstore.connection.bucket | default "mission-control-artifacts" }}
+    region: {{ .Values.artifactstore.connection.region | default "us-east-1" }}
+    url:
+      value: http://{{ include "incident-commander.artifactstore.name" . }}.{{ .Release.Namespace }}.svc:{{ .Values.artifactstore.service.port }}
+    usePathStyle: {{ .Values.artifactstore.connection.usePathStyle | default true }}
+    secretKey:
+      valueFrom:
+        secretKeyRef:
+          key: SECRET_ACCESS_KEY
+          name: {{ .Values.artifactstore.secretKeyRef.name }}
+{{- end }}
+  

--- a/chart/templates/artifactstore/connection.yaml
+++ b/chart/templates/artifactstore/connection.yaml
@@ -9,7 +9,7 @@ spec:
     accessKey:
       valueFrom:
         secretKeyRef:
-          key: {{ .Values.artifactstore.secretKeyRef.key | default "ACCESS_KEY_ID" }}
+          key: ACCESS_KEY_ID
           name: {{ .Values.artifactstore.secretKeyRef.name }}
     bucket: {{ .Values.artifactstore.connection.bucket | default "mission-control-artifacts" }}
     region: "us-east-1"

--- a/chart/templates/artifactstore/connection.yaml
+++ b/chart/templates/artifactstore/connection.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.artifactstore.enabled }}
+{{- if and .Values.artifactstore.enabled (eq .Values.artifactConnection "") }}
 ---
 apiVersion: mission-control.flanksource.com/v1
 kind: Connection

--- a/chart/templates/artifactstore/connection.yaml
+++ b/chart/templates/artifactstore/connection.yaml
@@ -14,7 +14,7 @@ spec:
     bucket: {{ .Values.artifactstore.connection.bucket | default "mission-control-artifacts" }}
     region: "us-east-1"
     url:
-      value: http://{{ include "incident-commander.artifactstore.name" . }}.{{ .Release.Namespace }}.svc:{{ .Values.artifactstore.service.port }}
+      value: http://{{ include "incident-commander.artifactstore.name" . }}.{{ .Release.Namespace }}.svc:8080
     usePathStyle: true
     secretKey:
       valueFrom:

--- a/chart/templates/artifactstore/deployment.yaml
+++ b/chart/templates/artifactstore/deployment.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.artifactstore.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "incident-commander.artifactstore.name" . }}
+  labels:
+    {{- include "incident-commander.labels" . | nindent 4 }}
+    {{- include "incident-commander.extraLabels" . | nindent 4 }}
+    {{- include "incident-commander.artifactstore.selectorLabels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "incident-commander.artifactstore.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "incident-commander.artifactstore.selectorLabels" . | nindent 8 }}
+        {{- include "incident-commander.extraLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: artifactstore
+          image: "{{ .Values.artifactstore.image.repository }}:{{ .Values.artifactstore.image.tag }}"
+          imagePullPolicy: {{ .Values.artifactstore.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              mkdir -p /data/{{ .Values.artifactstore.connection.bucket | default "mission-control-artifacts" }}
+              exec rclone serve s3 \
+                --addr :{{ .Values.artifactstore.service.port }} \
+                --auth-key "${ACCESS_KEY_ID},${SECRET_ACCESS_KEY}" \
+                /data
+          env:
+            - name: ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.artifactstore.secretKeyRef.name }}
+                  key: {{ .Values.artifactstore.secretKeyRef.key | default "ACCESS_KEY_ID" }}
+            - name: SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.artifactstore.secretKeyRef.name }}
+                  key: SECRET_ACCESS_KEY
+          ports:
+            - name: http
+              containerPort: {{ .Values.artifactstore.service.port }}
+          livenessProbe:
+            tcpSocket:
+              port: http
+          readinessProbe:
+            tcpSocket:
+              port: http
+          resources:
+            {{- toYaml .Values.artifactstore.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "incident-commander.artifactstore.pvc" . }}
+{{- end }}

--- a/chart/templates/artifactstore/deployment.yaml
+++ b/chart/templates/artifactstore/deployment.yaml
@@ -10,6 +10,8 @@ metadata:
     {{- include "incident-commander.artifactstore.selectorLabels" . | nindent 4 }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "incident-commander.artifactstore.selectorLabels" . | nindent 6 }}

--- a/chart/templates/artifactstore/deployment.yaml
+++ b/chart/templates/artifactstore/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         {{- include "incident-commander.extraLabels" . | nindent 8 }}
     spec:
       containers:
-        - name: artifactstore
+        - name: rclone
           image: "{{ .Values.artifactstore.image.repository }}:{{ .Values.artifactstore.image.tag }}"
           imagePullPolicy: {{ .Values.artifactstore.image.pullPolicy }}
           command:
@@ -31,7 +31,7 @@ spec:
             - |
               mkdir -p /data/{{ .Values.artifactstore.connection.bucket | default "mission-control-artifacts" }}
               exec rclone serve s3 \
-                --addr :{{ .Values.artifactstore.service.port }} \
+                --addr :8080 \
                 --auth-key "${ACCESS_KEY_ID},${SECRET_ACCESS_KEY}" \
                 /data
           env:
@@ -47,7 +47,7 @@ spec:
                   key: SECRET_ACCESS_KEY
           ports:
             - name: http
-              containerPort: {{ .Values.artifactstore.service.port }}
+              containerPort: 8080
           livenessProbe:
             tcpSocket:
               port: http

--- a/chart/templates/artifactstore/deployment.yaml
+++ b/chart/templates/artifactstore/deployment.yaml
@@ -39,7 +39,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.artifactstore.secretKeyRef.name }}
-                  key: {{ .Values.artifactstore.secretKeyRef.key | default "ACCESS_KEY_ID" }}
+                  key: ACCESS_KEY_ID
             - name: SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:

--- a/chart/templates/artifactstore/deployment.yaml
+++ b/chart/templates/artifactstore/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.artifactstore.enabled }}
+{{- if and .Values.artifactstore.enabled (eq .Values.artifactConnection "") }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/chart/templates/artifactstore/deployment.yaml
+++ b/chart/templates/artifactstore/deployment.yaml
@@ -30,10 +30,8 @@ spec:
             - -ec
             - |
               mkdir -p /data/{{ .Values.artifactstore.connection.bucket | default "mission-control-artifacts" }}
-              exec rclone serve s3 \
-                --addr :8080 \
-                --auth-key "${ACCESS_KEY_ID},${SECRET_ACCESS_KEY}" \
-                /data
+              export RCLONE_AUTH_KEY="\"${ACCESS_KEY_ID},${SECRET_ACCESS_KEY}\""
+              exec rclone serve s3 --addr :8080 /data
           env:
             - name: ACCESS_KEY_ID
               valueFrom:

--- a/chart/templates/artifactstore/pvc.yaml
+++ b/chart/templates/artifactstore/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.artifactstore.enabled (not .Values.artifactstore.volume.existingClaim) }}
+{{- if and .Values.artifactstore.enabled (eq .Values.artifactConnection "") (not .Values.artifactstore.volume.existingClaim) }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/chart/templates/artifactstore/pvc.yaml
+++ b/chart/templates/artifactstore/pvc.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.artifactstore.enabled (not .Values.artifactstore.volume.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "incident-commander.artifactstore.pvc" . }}
+  labels:
+    {{- include "incident-commander.labels" . | nindent 4 }}
+    {{- include "incident-commander.extraLabels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.artifactstore.volume.storageClass }}
+  storageClassName: {{ .Values.artifactstore.volume.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.artifactstore.volume.storage }}
+{{- end }}

--- a/chart/templates/artifactstore/secret.yaml
+++ b/chart/templates/artifactstore/secret.yaml
@@ -6,8 +6,7 @@
 {{- if and (not $hasClusterAccess) (eq (len $secretData) 0) }}
 {{- fail "artifactstore.secretKeyRef.create=true requires cluster access to keep credentials stable; disable create and provide a pre-existing Secret when using helm template/dry-run/GitOps rendering" }}
 {{- end }}
-{{- $accessKeyField := .Values.artifactstore.secretKeyRef.key | default "ACCESS_KEY_ID" }}
-{{- $accessKey := ((get $secretData $accessKeyField) | b64dec) | default (randAlphaNum 20) }}
+{{- $accessKey := ((get $secretData "ACCESS_KEY_ID") | b64dec) | default (randAlphaNum 20) }}
 {{- $secretKey := ((get $secretData "SECRET_ACCESS_KEY") | b64dec) | default (randAlphaNum 40) }}
 ---
 apiVersion: v1
@@ -19,6 +18,6 @@ metadata:
     {{- include "incident-commander.extraLabels" . | nindent 4 }}
 type: Opaque
 stringData:
-  {{ $accessKeyField }}: {{ $accessKey | quote }}
+  ACCESS_KEY_ID: {{ $accessKey | quote }}
   SECRET_ACCESS_KEY: {{ $secretKey | quote }}
 {{- end }}

--- a/chart/templates/artifactstore/secret.yaml
+++ b/chart/templates/artifactstore/secret.yaml
@@ -1,6 +1,11 @@
 {{- if and .Values.artifactstore.enabled (eq .Values.artifactConnection "") .Values.artifactstore.secretKeyRef.create }}
+{{- $clusterProbe := (lookup "v1" "Namespace" "" "kube-system") | default dict }}
+{{- $hasClusterAccess := gt (len $clusterProbe) 0 }}
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace .Values.artifactstore.secretKeyRef.name) | default dict }}
 {{- $secretData := (get $secretObj "data") | default dict }}
+{{- if and (not $hasClusterAccess) (eq (len $secretData) 0) }}
+{{- fail "artifactstore.secretKeyRef.create=true requires cluster access to keep credentials stable; disable create and provide a pre-existing Secret when using helm template/dry-run/GitOps rendering" }}
+{{- end }}
 {{- $accessKeyField := .Values.artifactstore.secretKeyRef.key | default "ACCESS_KEY_ID" }}
 {{- $accessKey := ((get $secretData $accessKeyField) | b64dec) | default (randAlphaNum 20) }}
 {{- $secretKey := ((get $secretData "SECRET_ACCESS_KEY") | b64dec) | default (randAlphaNum 40) }}
@@ -9,6 +14,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.artifactstore.secretKeyRef.name }}
+  labels:
+    {{- include "incident-commander.labels" . | nindent 4 }}
+    {{- include "incident-commander.extraLabels" . | nindent 4 }}
 type: Opaque
 stringData:
   {{ $accessKeyField }}: {{ $accessKey | quote }}

--- a/chart/templates/artifactstore/secret.yaml
+++ b/chart/templates/artifactstore/secret.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.artifactstore.enabled .Values.artifactstore.secretKeyRef.create }}
+{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace .Values.artifactstore.secretKeyRef.name) | default dict }}
+{{- $secretData := (get $secretObj "data") | default dict }}
+{{- $accessKeyField := .Values.artifactstore.secretKeyRef.key | default "ACCESS_KEY_ID" }}
+{{- $accessKey := ((get $secretData $accessKeyField) | b64dec) | default (randAlphaNum 20) }}
+{{- $secretKey := ((get $secretData "SECRET_ACCESS_KEY") | b64dec) | default (randAlphaNum 40) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.artifactstore.secretKeyRef.name }}
+type: Opaque
+stringData:
+  {{ $accessKeyField }}: {{ $accessKey | quote }}
+  SECRET_ACCESS_KEY: {{ $secretKey | quote }}
+{{- end }}

--- a/chart/templates/artifactstore/secret.yaml
+++ b/chart/templates/artifactstore/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.artifactstore.enabled .Values.artifactstore.secretKeyRef.create }}
+{{- if and .Values.artifactstore.enabled (eq .Values.artifactConnection "") .Values.artifactstore.secretKeyRef.create }}
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace .Values.artifactstore.secretKeyRef.name) | default dict }}
 {{- $secretData := (get $secretObj "data") | default dict }}
 {{- $accessKeyField := .Values.artifactstore.secretKeyRef.key | default "ACCESS_KEY_ID" }}

--- a/chart/templates/artifactstore/service.yaml
+++ b/chart/templates/artifactstore/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.artifactstore.enabled }}
+{{- if and .Values.artifactstore.enabled (eq .Values.artifactConnection "") }}
 ---
 apiVersion: v1
 kind: Service

--- a/chart/templates/artifactstore/service.yaml
+++ b/chart/templates/artifactstore/service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.artifactstore.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "incident-commander.artifactstore.name" . }}
+  labels:
+    {{- include "incident-commander.labels" . | nindent 4 }}
+    {{- include "incident-commander.extraLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "incident-commander.artifactstore.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.artifactstore.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/chart/templates/artifactstore/service.yaml
+++ b/chart/templates/artifactstore/service.yaml
@@ -13,7 +13,7 @@ spec:
     {{- include "incident-commander.artifactstore.selectorLabels" . | nindent 4 }}
   ports:
     - name: http
-      port: {{ .Values.artifactstore.service.port }}
+      port: 8080
       targetPort: http
       protocol: TCP
 {{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -120,6 +120,8 @@ spec:
            {{- end}}
            {{- if ne .Values.artifactConnection "" }}
             - --artifact-connection={{ .Values.artifactConnection }}
+           {{- else if .Values.artifactstore.enabled }}
+            - --artifact-connection=connection://{{ .Release.Namespace }}/{{ .Values.artifactstore.connection.name | default "default-artifactstore" }}
            {{- end }}
            {{- if ne .Values.kmsConnection "" }}
             - --secret-keeper-connection={{ .Values.kmsConnection }}

--- a/chart/test/basic_test.go
+++ b/chart/test/basic_test.go
@@ -15,7 +15,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("Mission Control", ginkgo.Ordered, Label("basic"), func() {
+var _ = Describe("Mission Control - Basic", ginkgo.Ordered, Label("basic"), func() {
 	var mcStopChan, configDBStopChan chan struct{}
 
 	BeforeAll(func() {
@@ -23,7 +23,7 @@ var _ = Describe("Mission Control", ginkgo.Ordered, Label("basic"), func() {
 
 		Expect(helm.NewHelmChart(ctx, "../").
 			Release("mission-control").Namespace("mission-control").
-			WaitFor(time.Minute * 5).
+			ForceConflicts().
 			Values(map[string]any{
 				"global": map[string]any{
 					"ui": map[string]any{
@@ -52,6 +52,9 @@ var _ = Describe("Mission Control", ginkgo.Ordered, Label("basic"), func() {
 		adminPassword := string(adminPasswordSecret.Data["password"])
 		Expect(adminPassword).NotTo(BeEmpty(), "Mission Control admin password should not be empty")
 		logger.Infof(clicky.MustFormat(adminPassword))
+
+		Expect(waitForPodReady(ctx, namespace, "app.kubernetes.io/name=mission-control", 5*time.Minute)).To(Succeed(), "mission-control pod should become ready")
+		Expect(waitForPodReady(ctx, namespace, "app.kubernetes.io/name=config-db", 5*time.Minute)).To(Succeed(), "config-db pod should become ready")
 
 		// Port forward to mission-control pod
 		var mcLocalPort int
@@ -120,6 +123,51 @@ var _ = Describe("Mission Control", ginkgo.Ordered, Label("basic"), func() {
 		scraper = mcInstanceWithoutAuth.GetScraper(uuid.Nil.String())
 		sr, err = scraper.Run()
 		Expect(err).NotTo(HaveOccurred(), "basic auth")
+	})
+
+	It("Should run the rclone artifactstore pod", func() {
+		Eventually(func(g Gomega) {
+			pods, err := k8s.CoreV1().Pods(namespace).List(context.TODO(), v1.ListOptions{
+				LabelSelector: "app.kubernetes.io/component=artifactstore",
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(pods.Items).NotTo(BeEmpty())
+
+			pod := pods.Items[0]
+			g.Expect(pod.Name).To(ContainSubstring("artifactstore"))
+			g.Expect(string(pod.Status.Phase)).To(Equal("Running"))
+
+			ready := false
+			for _, c := range pod.Status.ContainerStatuses {
+				if c.Name == "artifactstore" {
+					ready = c.Ready
+					break
+				}
+			}
+			g.Expect(ready).To(BeTrue())
+		}).WithTimeout(4 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+	})
+
+	It("Should test default artifactstore connection", func() {
+		connection, err := k8s.Get(context.TODO(), "Connection", namespace, "default-artifactstore")
+		Expect(err).NotTo(HaveOccurred(), "default-artifactstore connection should exist")
+
+		connectionID := string(connection.GetUID())
+		Expect(connectionID).NotTo(BeEmpty())
+
+		Eventually(func(g Gomega) {
+			response, err := mcInstance.POST("/connection/test/"+connectionID, nil)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(response.IsOK()).To(BeTrue())
+
+			body, err := response.AsJSON()
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(body["message"]).To(Equal("ok"))
+
+			payload, ok := body["payload"].(map[string]any)
+			g.Expect(ok).To(BeTrue())
+			g.Expect(fmt.Sprint(payload["status"])).NotTo(Equal("failed"), "artifactstore connection test returned failure: %v", payload["error"])
+		}).WithTimeout(20 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 	})
 
 	// System scraper runs and should populate job histories/local agent

--- a/chart/test/basic_test.go
+++ b/chart/test/basic_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Mission Control - Basic", ginkgo.Ordered, Label("basic"), func
 					},
 				},
 				"artifactstore": map[string]any{
-					"enabled": "true",
+					"enabled": true,
 				},
 				"authProvider": "basic",
 				"htpasswd": map[string]any{
@@ -170,7 +170,7 @@ var _ = Describe("Mission Control - Basic", ginkgo.Ordered, Label("basic"), func
 			payload, ok := body["payload"].(map[string]any)
 			g.Expect(ok).To(BeTrue())
 			g.Expect(fmt.Sprint(payload["status"])).To(Equal("success"), "artifactstore connection test did not reach success: status=%v error=%v", payload["status"], payload["error"])
-		}).WithTimeout(20 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+		}).WithTimeout(4 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 	})
 
 	// System scraper runs and should populate job histories/local agent

--- a/chart/test/basic_test.go
+++ b/chart/test/basic_test.go
@@ -30,6 +30,9 @@ var _ = Describe("Mission Control - Basic", ginkgo.Ordered, Label("basic"), func
 						"host": "mission-control.cluster.local",
 					},
 				},
+				"artifactstore": map[string]any{
+					"enabled": "true",
+				},
 				"authProvider": "basic",
 				"htpasswd": map[string]any{
 					"create": true,

--- a/chart/test/basic_test.go
+++ b/chart/test/basic_test.go
@@ -166,7 +166,7 @@ var _ = Describe("Mission Control - Basic", ginkgo.Ordered, Label("basic"), func
 
 			payload, ok := body["payload"].(map[string]any)
 			g.Expect(ok).To(BeTrue())
-			g.Expect(fmt.Sprint(payload["status"])).NotTo(Equal("failed"), "artifactstore connection test returned failure: %v", payload["error"])
+			g.Expect(fmt.Sprint(payload["status"])).To(Equal("success"), "artifactstore connection test did not reach success: status=%v error=%v", payload["status"], payload["error"])
 		}).WithTimeout(20 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 	})
 

--- a/chart/test/basic_test.go
+++ b/chart/test/basic_test.go
@@ -96,13 +96,13 @@ var _ = Describe("Mission Control - Basic", ginkgo.Ordered, Label("basic"), func
 	})
 
 	It("Should be healthy", func() {
-		healthy, err := mcInstance.IsHealthy()
+		healthy, statusCode, body, err := mcInstance.IsHealthy()
 		Expect(err).NotTo(HaveOccurred(), "Unable to query health endpoint")
-		Expect(healthy).To(BeTrue())
+		Expect(healthy).To(BeTrue(), "Expected mission-control to be healthy, got status code: %d, body: %s", statusCode, body)
 
-		healthy, err = mcInstanceWithoutAuth.IsHealthy()
+		healthy, statusCode, body, err = mcInstanceWithoutAuth.IsHealthy()
 		Expect(err).NotTo(HaveOccurred(), "Unable to query health endpoint")
-		Expect(healthy).To(BeTrue())
+		Expect(healthy).To(BeTrue(), "Expected mission-control (no auth) to be healthy, got status code: %d, body: %s", statusCode, body)
 	})
 
 	It("Should run WhoAmI", func() {
@@ -142,7 +142,7 @@ var _ = Describe("Mission Control - Basic", ginkgo.Ordered, Label("basic"), func
 
 			ready := false
 			for _, c := range pod.Status.ContainerStatuses {
-				if c.Name == "artifactstore" {
+				if c.Name == "rclone" {
 					ready = c.Ready
 					break
 				}
@@ -161,15 +161,11 @@ var _ = Describe("Mission Control - Basic", ginkgo.Ordered, Label("basic"), func
 		Eventually(func(g Gomega) {
 			response, err := mcInstance.POST("/connection/test/"+connectionID, nil)
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(response.IsOK()).To(BeTrue())
+			g.Expect(response.IsOK()).To(BeTrue(), "expected 200, got %d", response.StatusCode)
 
 			body, err := response.AsJSON()
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(body["message"]).To(Equal("ok"))
-
-			payload, ok := body["payload"].(map[string]any)
-			g.Expect(ok).To(BeTrue())
-			g.Expect(fmt.Sprint(payload["status"])).To(Equal("success"), "artifactstore connection test did not reach success: status=%v error=%v", payload["status"], payload["error"])
+			g.Expect(body["message"]).To(Equal("ok"), "unexpected response body: %v", body)
 		}).WithTimeout(4 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 	})
 

--- a/chart/test/go.mod
+++ b/chart/test/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/chromedp/chromedp v0.15.1
 	github.com/flanksource/commons v1.43.2
 	github.com/flanksource/commons-db v0.1.3
-	github.com/flanksource/commons-test v0.1.4
+	github.com/flanksource/commons-test v0.1.13
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.0
 	k8s.io/apimachinery v0.34.2

--- a/chart/test/go.mod
+++ b/chart/test/go.mod
@@ -225,7 +225,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/gorm v1.31.0 // indirect
-	k8s.io/api v0.34.2 // indirect
+	k8s.io/api v0.34.2
 	k8s.io/apiextensions-apiserver v0.34.2 // indirect
 	k8s.io/client-go v0.34.2
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/chart/test/go.sum
+++ b/chart/test/go.sum
@@ -101,8 +101,8 @@ github.com/flanksource/commons v1.43.2 h1:1UrE1lcx1iQ90ZL/JHAPLMbWdlO+iRT+xVajx9
 github.com/flanksource/commons v1.43.2/go.mod h1:xEBCobwaM0+EHn2SvFpqiCBJCVk1803An1kZleXFR9Y=
 github.com/flanksource/commons-db v0.1.3 h1:bhdzRxHhFsxy07a103zzxECnZvRrVFPE98Fm/EqMg04=
 github.com/flanksource/commons-db v0.1.3/go.mod h1:y8JZAOkoKN5aB/Q2McNnpMgur5Phi9X/mfaPVoiS8do=
-github.com/flanksource/commons-test v0.1.4 h1:4nOmys+epkCZ25mF/NqbItFotEVKckc03lyRjE+BiCs=
-github.com/flanksource/commons-test v0.1.4/go.mod h1:D8WZ9bj+FDBN1+TX4KPNECY95T3DlofsY0A/1AVKSqs=
+github.com/flanksource/commons-test v0.1.13 h1:DLb3q1a7d+BpfxZDy2bdY8ZA5z1+UTYFEO9DYd15bw4=
+github.com/flanksource/commons-test v0.1.13/go.mod h1:T0zLA9F55jlaOhtvjj1Ot7QZQhtn2baAuflT+27ueG8=
 github.com/flanksource/gomplate/v3 v3.24.60 h1:g1SjmR3m5YlXpuxyegvEj6OVbkoqP3btZbqUH0f7920=
 github.com/flanksource/gomplate/v3 v3.24.60/go.mod h1:hGEObNtnOQs8rNUX8sM8aJTAhnt4ehjyOw1MvDhl6AU=
 github.com/flanksource/is-healthy v1.0.82 h1:/hjq2hYWVph2Cr6F6qF4v/vTuEqOqgPVnZOh1kfDwvg=

--- a/chart/test/kratos_test.go
+++ b/chart/test/kratos_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Mission Control (Kratos)", ginkgo.Ordered, Label("kratos"), fu
 		host := "mission-control-kratos.cluster.local"
 		Expect(helm.NewHelmChart(ctx, "../").
 			Release(kratosReleaseName).Namespace(kratosNamespace).
-			WaitFor(time.Minute * 7).
+			ForceConflicts().
 			Values(map[string]any{
 				"cleanupResourcesOnDelete": true,
 				"authProvider":             "kratos",
@@ -83,6 +83,9 @@ var _ = Describe("Mission Control (Kratos)", ginkgo.Ordered, Label("kratos"), fu
 		Expect(err).NotTo(HaveOccurred(), "Failed to get admin password secret")
 		kratosTestPassword = string(adminSecret.Data["password"])
 		Expect(kratosTestPassword).NotTo(BeEmpty(), "Admin password should not be empty")
+
+		Expect(waitForPodReady(ctx, kratosNamespace, "app.kubernetes.io/name=mission-control", 7*time.Minute)).To(Succeed(), "mission-control pod should become ready")
+		Expect(waitForPodReady(ctx, kratosNamespace, "app.kubernetes.io/name=incident-manager-ui", 7*time.Minute)).To(Succeed(), "ui pod should become ready")
 
 		mcLocalPort, stopChan, err := portForwardPod(ctx, kratosNamespace, "app.kubernetes.io/name=mission-control", 8080)
 		Expect(err).NotTo(HaveOccurred(), "Failed to port forward to Mission Control pod")

--- a/chart/test/mission-control.go
+++ b/chart/test/mission-control.go
@@ -120,13 +120,14 @@ func (mc *MissionControl) SearchCatalog(search string) ([]SelectedResource, erro
 	return mc.QueryCatalog(ResourceSelector{Search: search})
 }
 
-func (mc *MissionControl) IsHealthy() (bool, error) {
+func (mc *MissionControl) IsHealthy() (bool, int, string, error) {
 	r, err := mc.HTTP.R(context.TODO()).Get("/health")
 	if err != nil {
-		return false, err
+		return false, 0, "", err
 	}
 
-	return r.IsOK(), nil
+	body, _ := r.AsString()
+	return r.IsOK(), r.StatusCode, body, nil
 }
 
 func (mc *MissionControl) WhoAmI() (map[string]any, bool, error) {

--- a/chart/test/utils_test.go
+++ b/chart/test/utils_test.go
@@ -114,8 +114,8 @@ func waitForPodReady(ctx context.Context, namespace, labelSelector string, timeo
 				if pod.Status.Phase != corev1.PodRunning {
 					continue
 				}
-				for _, cs := range pod.Status.ContainerStatuses {
-					if cs.Ready {
+				for _, condition := range pod.Status.Conditions {
+					if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
 						return nil
 					}
 				}

--- a/chart/test/utils_test.go
+++ b/chart/test/utils_test.go
@@ -106,7 +106,11 @@ func waitForPodReady(ctx context.Context, namespace, labelSelector string, timeo
 
 	for time.Now().Before(deadline) {
 		pods, err := k8s.CoreV1().Pods(namespace).List(ctx, v1.ListOptions{LabelSelector: labelSelector})
-		if err == nil && len(pods.Items) > 0 {
+		if err != nil {
+			return fmt.Errorf("failed to list pods matching selector %s in namespace %s: %w", labelSelector, namespace, err)
+		}
+
+		if len(pods.Items) > 0 {
 			for _, pod := range pods.Items {
 				if pod.DeletionTimestamp != nil {
 					continue

--- a/chart/test/utils_test.go
+++ b/chart/test/utils_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/portforward"
@@ -98,6 +99,37 @@ func portForwardService(ctx context.Context, namespace, serviceName string, remo
 
 	close(stopChan)
 	return 0, nil, fmt.Errorf("timed out waiting for kubectl port-forward to service %s\noutput: %s", serviceName, output.String())
+}
+
+func waitForPodReady(ctx context.Context, namespace, labelSelector string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		pods, err := k8s.CoreV1().Pods(namespace).List(ctx, v1.ListOptions{LabelSelector: labelSelector})
+		if err == nil && len(pods.Items) > 0 {
+			for _, pod := range pods.Items {
+				if pod.DeletionTimestamp != nil {
+					continue
+				}
+				if pod.Status.Phase != corev1.PodRunning {
+					continue
+				}
+				for _, cs := range pod.Status.ContainerStatuses {
+					if cs.Ready {
+						return nil
+					}
+				}
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+
+	return fmt.Errorf("timed out waiting for ready pod matching selector %s in namespace %s", labelSelector, namespace)
 }
 
 func portForwardResource(ctx context.Context, namespace, apiPath string, remotePort int) (int, chan struct{}, error) {

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -122,12 +122,6 @@
             "limits": {
               "additionalProperties": false,
               "properties": {
-                "cpu": {
-                  "default": "250m",
-                  "required": [],
-                  "title": "cpu",
-                  "type": "string"
-                },
                 "memory": {
                   "default": "256Mi",
                   "required": [],
@@ -136,7 +130,6 @@
                 }
               },
               "required": [
-                "cpu",
                 "memory"
               ],
               "title": "limits",
@@ -204,22 +197,6 @@
           "title": "secretKeyRef",
           "type": "object"
         },
-        "service": {
-          "additionalProperties": false,
-          "properties": {
-            "port": {
-              "default": 8080,
-              "required": [],
-              "title": "port",
-              "type": "integer"
-            }
-          },
-          "required": [
-            "port"
-          ],
-          "title": "service",
-          "type": "object"
-        },
         "volume": {
           "additionalProperties": false,
           "properties": {
@@ -254,7 +231,6 @@
       "required": [
         "enabled",
         "image",
-        "service",
         "connection",
         "volume",
         "secretKeyRef",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -55,13 +55,13 @@
     },
     "artifactstore": {
       "additionalProperties": false,
-      "description": "Extremely simple in-cluster S3-compatible server backed by rclone serve s3.",
+      "description": "Basic S3-compatible server backed by rclone serve s3.",
       "properties": {
         "connection": {
           "additionalProperties": false,
           "properties": {
             "bucket": {
-              "default": "mission-control-artifacts",
+              "default": "artifacts",
               "required": [],
               "title": "bucket",
               "type": "string"
@@ -175,13 +175,6 @@
               "title": "create",
               "type": "boolean"
             },
-            "key": {
-              "default": "ACCESS_KEY_ID",
-              "description": "Access key field name in the secret.",
-              "required": [],
-              "title": "key",
-              "type": "string"
-            },
             "name": {
               "default": "mission-control-artifactstore",
               "required": [],
@@ -191,8 +184,7 @@
           },
           "required": [
             "create",
-            "name",
-            "key"
+            "name"
           ],
           "title": "secretKeyRef",
           "type": "object"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -81,7 +81,7 @@
           "type": "object"
         },
         "enabled": {
-          "default": true,
+          "default": false,
           "required": [],
           "title": "enabled",
           "type": "boolean"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -57,6 +57,29 @@
       "additionalProperties": false,
       "description": "Extremely simple in-cluster S3-compatible server backed by rclone serve s3.",
       "properties": {
+        "connection": {
+          "additionalProperties": false,
+          "properties": {
+            "bucket": {
+              "default": "mission-control-artifacts",
+              "required": [],
+              "title": "bucket",
+              "type": "string"
+            },
+            "name": {
+              "default": "default-artifactstore",
+              "required": [],
+              "title": "name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "bucket"
+          ],
+          "title": "connection",
+          "type": "object"
+        },
         "enabled": {
           "default": true,
           "required": [],
@@ -79,7 +102,7 @@
               "type": "string"
             },
             "tag": {
-              "default": "1.71.2",
+              "default": "1.73.5",
               "required": [],
               "title": "tag",
               "type": "string"
@@ -91,43 +114,6 @@
             "pullPolicy"
           ],
           "title": "image",
-          "type": "object"
-        },
-        "connection": {
-          "additionalProperties": false,
-          "properties": {
-            "bucket": {
-              "default": "mission-control-artifacts",
-              "required": [],
-              "title": "bucket",
-              "type": "string"
-            },
-            "name": {
-              "default": "default-artifactstore",
-              "required": [],
-              "title": "name",
-              "type": "string"
-            },
-            "region": {
-              "default": "us-east-1",
-              "required": [],
-              "title": "region",
-              "type": "string"
-            },
-            "usePathStyle": {
-              "default": true,
-              "required": [],
-              "title": "usePathStyle",
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "name",
-            "bucket",
-            "region",
-            "usePathStyle"
-          ],
-          "title": "connection",
           "type": "object"
         },
         "resources": {

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -53,6 +53,229 @@
       "required": [],
       "title": "artifactConnection"
     },
+    "artifactstore": {
+      "additionalProperties": false,
+      "description": "Extremely simple in-cluster S3-compatible server backed by rclone serve s3.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "image": {
+          "additionalProperties": false,
+          "properties": {
+            "pullPolicy": {
+              "default": "IfNotPresent",
+              "required": [],
+              "title": "pullPolicy",
+              "type": "string"
+            },
+            "repository": {
+              "default": "docker.io/rclone/rclone",
+              "required": [],
+              "title": "repository",
+              "type": "string"
+            },
+            "tag": {
+              "default": "1.71.2",
+              "required": [],
+              "title": "tag",
+              "type": "string"
+            }
+          },
+          "required": [
+            "repository",
+            "tag",
+            "pullPolicy"
+          ],
+          "title": "image",
+          "type": "object"
+        },
+        "connection": {
+          "additionalProperties": false,
+          "properties": {
+            "bucket": {
+              "default": "mission-control-artifacts",
+              "required": [],
+              "title": "bucket",
+              "type": "string"
+            },
+            "name": {
+              "default": "default-artifactstore",
+              "required": [],
+              "title": "name",
+              "type": "string"
+            },
+            "region": {
+              "default": "us-east-1",
+              "required": [],
+              "title": "region",
+              "type": "string"
+            },
+            "usePathStyle": {
+              "default": true,
+              "required": [],
+              "title": "usePathStyle",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "name",
+            "bucket",
+            "region",
+            "usePathStyle"
+          ],
+          "title": "connection",
+          "type": "object"
+        },
+        "resources": {
+          "additionalProperties": false,
+          "properties": {
+            "limits": {
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "default": "250m",
+                  "required": [],
+                  "title": "cpu",
+                  "type": "string"
+                },
+                "memory": {
+                  "default": "256Mi",
+                  "required": [],
+                  "title": "memory",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "cpu",
+                "memory"
+              ],
+              "title": "limits",
+              "type": "object"
+            },
+            "requests": {
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "default": "25m",
+                  "required": [],
+                  "title": "cpu",
+                  "type": "string"
+                },
+                "memory": {
+                  "default": "64Mi",
+                  "required": [],
+                  "title": "memory",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "cpu",
+                "memory"
+              ],
+              "title": "requests",
+              "type": "object"
+            }
+          },
+          "required": [
+            "requests",
+            "limits"
+          ],
+          "title": "resources",
+          "type": "object"
+        },
+        "secretKeyRef": {
+          "additionalProperties": false,
+          "properties": {
+            "create": {
+              "default": true,
+              "required": [],
+              "title": "create",
+              "type": "boolean"
+            },
+            "key": {
+              "default": "ACCESS_KEY_ID",
+              "description": "Access key field name in the secret.",
+              "required": [],
+              "title": "key",
+              "type": "string"
+            },
+            "name": {
+              "default": "mission-control-artifactstore",
+              "required": [],
+              "title": "name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "create",
+            "name",
+            "key"
+          ],
+          "title": "secretKeyRef",
+          "type": "object"
+        },
+        "service": {
+          "additionalProperties": false,
+          "properties": {
+            "port": {
+              "default": 8080,
+              "required": [],
+              "title": "port",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "port"
+          ],
+          "title": "service",
+          "type": "object"
+        },
+        "volume": {
+          "additionalProperties": false,
+          "properties": {
+            "existingClaim": {
+              "default": "",
+              "required": [],
+              "title": "existingClaim",
+              "type": "string"
+            },
+            "storage": {
+              "default": "10Gi",
+              "required": [],
+              "title": "storage",
+              "type": "string"
+            },
+            "storageClass": {
+              "default": "",
+              "required": [],
+              "title": "storageClass",
+              "type": "string"
+            }
+          },
+          "required": [
+            "existingClaim",
+            "storageClass",
+            "storage"
+          ],
+          "title": "volume",
+          "type": "object"
+        }
+      },
+      "required": [
+        "enabled",
+        "image",
+        "service",
+        "connection",
+        "volume",
+        "secretKeyRef",
+        "resources"
+      ],
+      "title": "artifactstore"
+    },
     "authProvider": {
       "default": "kratos",
       "description": "Allowed values are [none, kratos, clerk, basic]",
@@ -372,7 +595,7 @@
                   "type": "string"
                 },
                 "image": {
-                  "default": "bitnami/pgbouncer:1.22.0",
+                  "default": "pgbouncer/pgbouncer:1.22.0",
                   "required": [],
                   "title": "image",
                   "type": "string"
@@ -663,7 +886,7 @@
           "title": "repository"
         },
         "tag": {
-          "default": "v0.0.1565",
+          "default": "v0.0.1711",
           "required": [],
           "title": "tag"
         }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -256,7 +256,7 @@ kmsConnection: ""
 # -- llm connection string
 llmConnection: ""
 
-# Extremely simple in-cluster S3-compatible server backed by rclone serve s3.
+# Basic S3-compatible server backed by rclone serve s3.
 # @schema
 # required: false
 # @schema
@@ -268,7 +268,7 @@ artifactstore:
     pullPolicy: IfNotPresent
   connection:
     name: default-artifactstore
-    bucket: mission-control-artifacts
+    bucket: artifacts
   volume:
     existingClaim: ""
     storageClass: ""
@@ -276,8 +276,6 @@ artifactstore:
   secretKeyRef:
     create: true
     name: mission-control-artifactstore
-    # Access key field name in the secret.
-    key: ACCESS_KEY_ID
   resources:
     requests:
       cpu: 25m

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -255,6 +255,41 @@ kmsConnection: ""
 # @schema
 # -- llm connection string
 llmConnection: ""
+
+# Extremely simple in-cluster S3-compatible server backed by rclone serve s3.
+# @schema
+# required: false
+# @schema
+artifactstore:
+  enabled: true
+  image:
+    repository: docker.io/rclone/rclone
+    tag: "1.71.2"
+    pullPolicy: IfNotPresent
+  service:
+    port: 8080
+  connection:
+    name: default-artifactstore
+    bucket: mission-control-artifacts
+    region: us-east-1
+    usePathStyle: true
+  volume:
+    existingClaim: ""
+    storageClass: ""
+    storage: 10Gi
+  secretKeyRef:
+    create: true
+    name: mission-control-artifactstore
+    # Access key field name in the secret.
+    key: ACCESS_KEY_ID
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+
 # Properties to configure mission-control feature sets
 # @schema
 # required: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -264,15 +264,13 @@ artifactstore:
   enabled: true
   image:
     repository: docker.io/rclone/rclone
-    tag: "1.71.2"
+    tag: "1.73.5"
     pullPolicy: IfNotPresent
   service:
     port: 8080
   connection:
     name: default-artifactstore
     bucket: mission-control-artifacts
-    region: us-east-1
-    usePathStyle: true
   volume:
     existingClaim: ""
     storageClass: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -261,7 +261,7 @@ llmConnection: ""
 # required: false
 # @schema
 artifactstore:
-  enabled: true
+  enabled: false
   image:
     repository: docker.io/rclone/rclone
     tag: "1.73.5"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -266,8 +266,6 @@ artifactstore:
     repository: docker.io/rclone/rclone
     tag: "1.73.5"
     pullPolicy: IfNotPresent
-  service:
-    port: 8080
   connection:
     name: default-artifactstore
     bucket: mission-control-artifacts
@@ -285,7 +283,6 @@ artifactstore:
       cpu: 25m
       memory: 64Mi
     limits:
-      cpu: 250m
       memory: 256Mi
 
 # Properties to configure mission-control feature sets


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable artifact store (S3-compatible rclone backend) with image, storage, credentials, PVC and connection options; added top-level OIDC, kratos secret name override, and views.database.enabled values.

* **Tests**
  * E2E tests updated to enable artifactstore, wait for pod readiness, and validate artifactstore connection and probe readiness.

* **Chores**
  * Bumped component/chart versions and app image tag; changed default DB connection pooler image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->