### PR TITLE
fix: duplicate labels on artifact store

### DIFF
--- a/chart/templates/artifactstore/deployment.yaml
+++ b/chart/templates/artifactstore/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "incident-commander.labels" . | nindent 4 }}
     {{- include "incident-commander.extraLabels" . | nindent 4 }}
-    {{- include "incident-commander.artifactstore.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: artifactstore
 spec:
   replicas: 1
   strategy:


### PR DESCRIPTION
```
Helm upgrade failed for release mission-control/mission-control-mission-control-beta-mission-control-tenant with chart mission-control@0.1.314-beta.13: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
  line 14: mapping key "app.kubernetes.io/name" already defined at line 8
  line 15: mapping key "app.kubernetes.io/instance" already defined at line 9
  line 16: mapping key "control-plane" already defined at line 10

```