### PR TITLE
fix(chart): prevent mission-control service from selecting artifactstore pods

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -40,12 +40,24 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
-Selector labels
+Base selector labels shared by incident-commander workloads.
 */}}
 {{- define "incident-commander.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "incident-commander.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 control-plane: incident-commander
+{{- end }}
+
+{{/*
+Stable selector labels for the main mission-control pods.
+
+This is intentionally a superset of incident-commander.selectorLabels so it can
+be used for pod template labels and Service selectors without changing the
+immutable Deployment selector on upgrade.
+*/}}
+{{- define "incident-commander.missionControl.selectorLabels" -}}
+{{ include "incident-commander.selectorLabels" . }}
+app.kubernetes.io/component: mission-control
 {{- end }}
 
 {{- define "incident-commander.extraLabels" -}}

--- a/chart/templates/artifactstore/service.yaml
+++ b/chart/templates/artifactstore/service.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "incident-commander.artifactstore.name" . }}
   labels:
     {{- include "incident-commander.labels" . | nindent 4 }}
+    app.kubernetes.io/component: artifactstore
     {{- include "incident-commander.extraLabels" . | nindent 4 }}
 spec:
   type: ClusterIP

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "incident-commander.name" . }}
   labels:
     {{- include "incident-commander.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mission-control
     {{- include "incident-commander.extraLabels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
@@ -14,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "incident-commander.selectorLabels" . | nindent 8 }}
+        {{- include "incident-commander.missionControl.selectorLabels" . | nindent 8 }}
         {{- include "incident-commander.extraLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "incident-commander.name" . }}
   labels:
     {{- include "incident-commander.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mission-control
 spec:
   ports:
     - port: 8080
@@ -17,4 +18,4 @@ spec:
       name: metrics
     {{- end }}
   selector:
-    {{- include "incident-commander.selectorLabels" . | nindent 4 }}
+    {{- include "incident-commander.missionControl.selectorLabels" . | nindent 4 }}

--- a/chart/templates/servicemonitor.yaml
+++ b/chart/templates/servicemonitor.yaml
@@ -15,5 +15,5 @@ spec:
       interval: 30s
   selector:
     matchLabels:
-      {{- include "incident-commander.labels" . | nindent 6 }}
+      {{- include "incident-commander.missionControl.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/chart/test/basic_test.go
+++ b/chart/test/basic_test.go
@@ -56,13 +56,13 @@ var _ = Describe("Mission Control - Basic", ginkgo.Ordered, Label("basic"), func
 		Expect(adminPassword).NotTo(BeEmpty(), "Mission Control admin password should not be empty")
 		logger.Infof(clicky.MustFormat(adminPassword))
 
-		Expect(waitForPodReady(ctx, namespace, "app.kubernetes.io/name=mission-control", 5*time.Minute)).To(Succeed(), "mission-control pod should become ready")
+		Expect(waitForPodReady(ctx, namespace, missionControlSelector, 5*time.Minute)).To(Succeed(), "mission-control pod should become ready")
 		Expect(waitForPodReady(ctx, namespace, "app.kubernetes.io/name=config-db", 5*time.Minute)).To(Succeed(), "config-db pod should become ready")
 
-		// Port forward to mission-control pod
+		// Port forward to mission-control service so tests validate the Service selector too.
 		var mcLocalPort int
-		mcLocalPort, mcStopChan, err = portForwardPod(ctx, namespace, "app.kubernetes.io/name=mission-control", 8080)
-		Expect(err).NotTo(HaveOccurred(), "Failed to port forward to Mission Control pod")
+		mcLocalPort, mcStopChan, err = portForwardService(ctx, namespace, "mission-control", 8080)
+		Expect(err).NotTo(HaveOccurred(), "Failed to port forward to Mission Control service")
 
 		// Port forward to config-db pod
 		var configDBLocalPort int

--- a/chart/test/kratos_test.go
+++ b/chart/test/kratos_test.go
@@ -84,11 +84,11 @@ var _ = Describe("Mission Control (Kratos)", ginkgo.Ordered, Label("kratos"), fu
 		kratosTestPassword = string(adminSecret.Data["password"])
 		Expect(kratosTestPassword).NotTo(BeEmpty(), "Admin password should not be empty")
 
-		Expect(waitForPodReady(ctx, kratosNamespace, "app.kubernetes.io/name=mission-control", 7*time.Minute)).To(Succeed(), "mission-control pod should become ready")
+		Expect(waitForPodReady(ctx, kratosNamespace, missionControlSelector, 7*time.Minute)).To(Succeed(), "mission-control pod should become ready")
 		Expect(waitForPodReady(ctx, kratosNamespace, "app.kubernetes.io/name=incident-manager-ui", 7*time.Minute)).To(Succeed(), "ui pod should become ready")
 
-		mcLocalPort, stopChan, err := portForwardPod(ctx, kratosNamespace, "app.kubernetes.io/name=mission-control", 8080)
-		Expect(err).NotTo(HaveOccurred(), "Failed to port forward to Mission Control pod")
+		mcLocalPort, stopChan, err := portForwardService(ctx, kratosNamespace, "mission-control", 8080)
+		Expect(err).NotTo(HaveOccurred(), "Failed to port forward to Mission Control service")
 		kratosMCStopChan = stopChan
 
 		kratosMC = &MissionControl{

--- a/chart/test/utils_test.go
+++ b/chart/test/utils_test.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/client-go/transport/spdy"
 )
 
+const missionControlSelector = "app.kubernetes.io/name=mission-control,app.kubernetes.io/component=mission-control"
+
 // portForwardPod sets up port forwarding to a pod matching the given label selector.
 // Returns the local port, a stop channel to close when done, and any error.
 func portForwardPod(ctx context.Context, namespace, labelSelector string, remotePort int) (int, chan struct{}, error) {

--- a/test/test.sh
+++ b/test/test.sh
@@ -56,7 +56,7 @@ header "Kratos Logs"
 kubectl -n default logs -l app.kubernetes.io/name=kratos --tail 100
 
 header "Mission Control Logs"
-kubectl -n default logs -l app.kubernetes.io/name=mission-control --tail 100
+kubectl -n default logs -l app.kubernetes.io/name=mission-control,app.kubernetes.io/component=mission-control --tail 100
 
 if [[ "$SUCCESS" == "1" ]]; then
     exit 1


### PR DESCRIPTION
The `mission-control` Service selected only shared app/release labels, so it also matched the artifactstore pod.

Artifactstore is part of the same Helm release and intentionally shares `app.kubernetes.io/name` and `app.kubernetes.io/instance`, but it needs its own workload identity.

Add workload-specific `app.kubernetes.io/component` labels and make the mission-control and artifactstore Services select their respective components. This keeps Deployment selectors unchanged while isolating traffic correctly.