### PR TITLE
feat: expose chart version to mission control

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -38,6 +38,8 @@ spec:
           image: "{{ .Values.global.imageRegistry }}/{{.Values.global.imagePrefix}}/incident-commander:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            - name: FLANKSOURCE_CHART_VERSION
+              value: {{ .Chart.Version | quote }}
             {{- if (tpl .Values.otel.labels .)}}
             - name: OTEL_LABELS
               value: "{{(tpl .Values.otel.labels .)}}"


### PR DESCRIPTION
Set FLANKSOURCE_CHART_VERSION on the mission-control container so the backend can report the Helm chart version when installed from Helm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Chart version is now accessible as an environment variable in deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->