### PR TITLE
fix: grant plugin RBAC permissions

### DIFF
--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -36,6 +36,7 @@ rules:
   - permissiongroups
   - permissions
   - playbooks
+  - plugins
   - scopes
   - views
   verbs:
@@ -56,6 +57,7 @@ rules:
   - notificationsilences/finalizers
   - permissiongroups/finalizers
   - permissions/finalizers
+  - plugins/finalizers
   - views/finalizers
   - applications/finalizers
   - scopes/finalizers
@@ -71,6 +73,7 @@ rules:
   - notificationsilences/status
   - permissiongroups/status
   - permissions/status
+  - plugins/status
   - views/status
   - applications/status
   - scopes/status


### PR DESCRIPTION
Mission Control plugin reconciliation was failing when kopper tried to update plugin finalizers.

The service account RBAC covered other mission-control CRDs but omitted `plugins`, causing forbidden errors on update/finalizer/status operations.

Add `plugins`, `plugins/finalizers`, and `plugins/status` to the chart RBAC rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended RBAC permissions to grant service account access to the plugins resource with full CRUD operations, including specific permissions for plugins/finalizers and plugins/status sub-resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/mission-control-chart/pull/581?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->