### PR TITLE
fix: render extra RBAC rules without extra indentation

### DIFF
--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -144,7 +144,7 @@ rules:
     - watch
 {{- end}}
 {{- if .Values.serviceAccount.rbac.extra }}
-{{ .Values.serviceAccount.rbac.extra | toYaml | nindent 2 }}
+{{ .Values.serviceAccount.rbac.extra | toYaml }}
 {{- end}}
 {{- if .Values.serviceAccount.rbac.clusterAdmin }}
 ---


### PR DESCRIPTION
serviceAccount.rbac.extra entries are already expected to render as RBAC rule list items.

The template applied nindent 2, which over-indented the extra rules under rules: and produced invalid or misplaced YAML. Render the provided YAML directly so extra RBAC rules align with the rest of the rule list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed formatting of custom RBAC rules in Helm chart-generated Kubernetes manifests to ensure correct configuration embedding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/mission-control-chart/pull/591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->